### PR TITLE
Update ruralline_legacy_v3_upo.lua

### DIFF
--- a/lua/metrostroi/maps/ruralline_legacy_v3_upo.lua
+++ b/lua/metrostroi/maps/ruralline_legacy_v3_upo.lua
@@ -13,7 +13,7 @@ Metrostroi.SetUPOAnnouncer	(
 	{
 		--Announcer Startup
 		name = "UPO ruralline",
-		tone = {"subway_announcers/upo_treschev/tone.mp3", 1.1},
+		tone = {"subway_announcers/sarmat_upo/tone.mp3", 1.1},
 		click1 = {"subway_announcers/upo/click1.mp3", 0.3},
 		click2 = {"subway_announcers/upo/click2.mp3", 0.1},
 		--Stations


### PR DESCRIPTION
take upo tone from official metrostroi content, removes unnecessary dependency